### PR TITLE
Add initial implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+**/*.bundle.*
 build
 coverage
 node_modules

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.25)
+
+find_package(cmake-bare-bundle REQUIRED PATHS node_modules/cmake-bare-bundle)
+find_package(cmake-fetch REQUIRED PATHS node_modules/cmake-fetch)
+
+fetch_package("github:holepunchto/bare@1.16.2")
+
+set(name bare_test)
+
+set(BUNDLE_OUT lib/test.bundle.h)
+
+project(${name} C)
+
+add_bare_bundle(
+  ${name}_bundle
+  ENTRY ${TEST_FILE}
+  OUT ${BUNDLE_OUT}
+  BUILTINS lib/builtins.json
+)
+
+add_executable(${name})
+
+target_sources(
+  ${name}
+  PRIVATE
+    ${BUNDLE_OUT}
+    lib/testbed.c
+)
+
+set_target_properties(
+  ${name}
+  PROPERTIES
+  OUTPUT_NAME test
+  ENABLE_EXPORTS ON
+  MACOSX_BUNDLE OFF
+  WINDOWS_EXPORT_ALL_SYMBOLS ON
+)
+
+target_link_libraries(
+  ${name}
+  PUBLIC
+    $<LINK_LIBRARY:WHOLE_ARCHIVE,bare_static>
+)
+
+link_bare_modules(${name})
+
+install(TARGETS ${name})

--- a/bin.js
+++ b/bin.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+const { command, arg, flag, summary } = require('paparam')
+const path = require('path')
+const process = require('process')
+const pkg = require('./package')
+const test = require('.')
+
+const cmd = command(
+  pkg.name,
+  summary(pkg.description),
+  flag('--platform|-p <name>', 'The operating system platform to build for'),
+  flag('--arch|-a <name>', 'The operating system architecture of the emulator'),
+  flag('--device|-d <name>', 'The name of the device to launch'),
+  flag('--simulator', 'Build for a simulator'),
+  arg('<testfile>', 'The name of the test script to run'),
+  () => {
+    const { platform, arch, device, simulator } = cmd.flags
+    const testfile = path.resolve(process.cwd(), cmd.args.testfile)
+
+    test(testfile, { platform, arch, device, simulator })
+  }
+)
+
+cmd.parse()

--- a/index.js
+++ b/index.js
@@ -1,1 +1,80 @@
-console.log('bare-test')
+const make = require('bare-make')
+const os = require('os')
+const path = require('path')
+const process = require('process')
+const subprocess = require('child_process')
+const which = require('bare-which')
+
+module.exports = function test(entry, opts) {
+  if (opts.platform === 'android') android(entry, opts)
+  else if (opts.platform === 'ios') ios(entry, opts)
+  else desktop(entry, opts)
+}
+
+async function android(entry, opts) {
+  const sdk =
+    process.env.ANDROID_HOME || path.join(os.homedir(), '.android/sdk')
+  const adb = which.sync('adb', { path: path.join(sdk, 'platform-tools') })
+
+  await build(entry, opts)
+
+  const deviceArgs = opts.device ? ['-s', opts.device] : []
+
+  spawn(adb, [...deviceArgs, 'push', 'prebuilds/bin/test', '/data/bin/test'])
+
+  spawn(
+    adb,
+    [...deviceArgs, 'shell', '/data/bin/test'],
+    { stdio: 'inherit' },
+    false
+  )
+
+  spawn(adb, [...deviceArgs, 'shell', 'rm', '/data/bin/test'])
+}
+
+async function ios(entry, opts) {
+  const xcrun = which.sync('xcrun')
+
+  const simctl = exec(xcrun, ['--find', 'simctl'], { stdio: 'pipe' })
+    .toString()
+    .trim()
+
+  await build(entry, opts)
+
+  spawn(
+    simctl,
+    ['spawn', opts.device, 'prebuilds/bin/test'],
+    { stdio: 'inherit' },
+    false
+  )
+}
+
+function desktop(entry) {
+  exec(which.sync('bare'), [entry], { stdio: 'inherit' }, false)
+}
+
+async function build(entry, opts = {}) {
+  opts = { ...opts, cwd: __dirname }
+
+  await make.generate({ define: [`TEST_FILE=${entry}`], ...opts })
+  await make.build(opts)
+  await make.install(opts)
+}
+
+function exec(file, args = [], opts = {}, throwError = true) {
+  try {
+    return subprocess.execFileSync(file, args, opts)
+  } catch (err) {
+    process.exitCode = 1
+    if (throwError) throw err
+  }
+}
+
+function spawn(cmd, args = [], opts = {}, throwError = true) {
+  const proc = subprocess.spawnSync(cmd, args, opts)
+
+  if (proc.status) {
+    process.exitCode = 1
+    if (throwError) throw new Error('spawn() failed')
+  }
+}

--- a/lib/builtins.json
+++ b/lib/builtins.json
@@ -1,0 +1,12 @@
+[
+  { "addon": "bare-buffer" },
+  { "addon": "bare-hrtime" },
+  { "addon": "bare-inspect" },
+  { "addon": "bare-logger" },
+  { "addon": "bare-module" },
+  { "addon": "bare-module-lexer" },
+  { "addon": "bare-os" },
+  { "addon": "bare-structured-clone" },
+  { "addon": "bare-timers" },
+  { "addon": "bare-url" }
+]

--- a/lib/testbed.c
+++ b/lib/testbed.c
@@ -1,0 +1,40 @@
+#include <assert.h>
+#include <bare.h>
+#include <uv.h>
+
+#include "test.bundle.h"
+
+int main(int argc, char *argv[]) {
+  int err;
+
+  argv = uv_setup_args(argc, argv);
+
+  js_platform_t *platform;
+  err = js_create_platform(uv_default_loop(), NULL, &platform);
+  assert(err == 0);
+
+  bare_t *bare;
+  err = bare_setup(uv_default_loop(), platform, NULL, argc, (const char **)argv,
+                   NULL, &bare);
+  assert(err == 0);
+
+  uv_buf_t source = uv_buf_init((char *)test_bundle, test_bundle_len);
+
+  err = bare_load(bare, "/test.bundle", &source, NULL);
+  assert(err == 0);
+
+  err = bare_run(bare);
+  assert(err == 0);
+
+  int exit_code;
+  err = bare_teardown(bare, &exit_code);
+  assert(err == 0);
+
+  err = js_destroy_platform(platform);
+  assert(err == 0);
+
+  err = uv_run(uv_default_loop(), UV_RUN_ONCE);
+  assert(err == 0);
+
+  return exit_code;
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     ".": "./index.js",
     "./package": "./package.json"
   },
+  "bin": {
+    "bare-test": "bin.js"
+  },
   "files": [
     "index.js"
   ],
@@ -26,7 +29,24 @@
     "bare": ">=1.16.0"
   },
   "devDependencies": {
+    "cmake-bare-bundle": "^2.1.4",
     "prettier": "^3.4.1",
     "prettier-config-standard": "^7.0.0"
+  },
+  "dependencies": {
+    "bare-buffer": "^3.1.2",
+    "bare-hrtime": "^2.0.10",
+    "bare-inspect": "^3.0.6",
+    "bare-logger": "^1.0.1",
+    "bare-make": "^1.4.0",
+    "bare-module": "^4.8.2",
+    "bare-module-lexer": "^1.2.0",
+    "bare-os": "^3.6.0",
+    "bare-structured-clone": "^1.4.2",
+    "bare-timers": "^3.0.1",
+    "bare-url": "^2.1.3",
+    "bare-which": "^2.0.0",
+    "cmake-fetch": "^1.4.0",
+    "paparam": "^1.8.0"
   }
 }


### PR DESCRIPTION
I pushed the branches in the wrong order and I wasn't able to change the default branch to `main`.

As the current implementation isn't addressing all the requirements, I wanted to create a PR first.

---

There are a few things to resolve:

- **Native addons**
 
.bare binaries aren't getting found.

Compiling tests for bare-os triggers:

```
Uncaught Error: No addon registered for 'bare-os@3.4.0'
    at Addon.load (bare:/bare.js:5292:32)
    at require.addon (bare:/bare.js:8594:30)
    at file:///bare-os/node_modules/bare-os/binding.js:1:26
    at Module._evaluate (bare:/bare.js:8050:7)
    at Module._transform (bare:/bare.js:7958:12)
    at Module.load (bare:/bare.js:8297:21)
    at require (bare:/bare.js:8573:25)
    at file:///bare-os/node_modules/bare-os/index.js:1:17
    at Module._evaluate (bare:/bare.js:8050:7)
    at Module._transform (bare:/bare.js:7958:12)
```

and for bare-dns triggers:

```
Uncaught Error: dlopen(/bare-tcp/node_modules/bare-dns/prebuilds/darwin-arm64/bare-dns.bare, 0x0005): tried: '/bare-tcp/node_modules/bare-dns/prebuilds/darwin-arm64/bare-dns.bare' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/bare-tcp/node_modules/bare-dns/prebuilds/darwin-arm64/bare-dns.bare' (no such file), '/bare-tcp/node_modules/bare-dns/prebuilds/darwin-arm64/bare-dns.bare' (no such file)
    at Addon.load (bare:/bare.js:5309:32)
    at require.addon (bare:/bare.js:8594:30)
    at file:///bare-tcp/node_modules/bare-dns/binding.js:1:26
    at Module._evaluate (bare:/bare.js:8050:7)
    at Module._transform (bare:/bare.js:7958:12)
    at Module.load (bare:/bare.js:8297:21)
    at require (bare:/bare.js:8573:25)
    at file:///bare-tcp/node_modules/bare-dns/index.js:1:17
    at Module._evaluate (bare:/bare.js:8050:7)
    at Module._transform (bare:/bare.js:7958:12)
zsh: abort      ./test
```

- **Use `cmake-bare-bundle` as dependency, not devDependency**

using as dependency triggers:

```
-- Configuring done (229.9s)
-- Generating done (0.2s)
-- Build files have been written to: /Users/.../bare-test/build
[0/2] Re-checking globbed directories...
[238/239] Linking C executable test
FAILED: test
...
ld: 167 duplicate symbols
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```
- **Android exit code**

As `bare-test` being a test runner, I tried to return the exit code based on the test results, but for android I hit the issue: 

https://stackoverflow.com/questions/17480028/get-result-code-of-adb-shell-command
